### PR TITLE
Add VM Id Suffix

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -40,6 +40,7 @@ actions_preinstalled=
 maintenance_policy_terminate=
 arm=
 accelerator=
+vm_id=
 
 OPTLIND=1
 while getopts_long :h opt \
@@ -67,6 +68,7 @@ while getopts_long :h opt \
   arm required_argument \
   maintenance_policy_terminate optional_argument \
   accelerator optional_argument \
+  vm_id optional_argument \
   help no_argument "" "$@"
 do
   case "$opt" in
@@ -141,7 +143,10 @@ do
       ;;
     accelerator)
       accelerator=$OPTLARG
-      ;;      
+      ;;    
+    vm_id)
+      vm_id=$OPTLARG
+      ;;     
     h|help)
       usage
       exit 0
@@ -175,7 +180,8 @@ function start_vm {
       jq -r .token)
   echo "✅ Successfully got the GitHub Runner registration token"
 
-  VM_ID="gce-gh-runner-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+  vm_suffix=$([[ -z "${vm_id}" ]] || echo "-${vm_id}")
+  VM_ID="gce-gh-runner-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}${vm_suffix}"
   service_account_flag=$([[ -z "${runner_service_account}" ]] || echo "--service-account=${runner_service_account}")
   image_project_flag=$([[ -z "${image_project}" ]] || echo "--image-project=${image_project}")
   image_flag=$([[ -z "${image}" ]] || echo "--image=${image}")

--- a/action.sh
+++ b/action.sh
@@ -215,7 +215,7 @@ function start_vm {
 
 	cat <<-EOF > /usr/bin/gce_runner_shutdown.sh
 	#!/bin/sh
-  /actions-runner/config.sh remove --token ${RUNNER_TOKEN}
+  RUNNER_ALLOW_RUNASROOT=1 /actions-runner/config.sh remove --token ${RUNNER_TOKEN}
 	echo \"✅ Self deleting $VM_ID in ${machine_zone} in ${shutdown_timeout} seconds ...\"
 	# We tear down the machine by starting the systemd service that was registered by the startup script
 	systemctl start shutdown.service

--- a/action.sh
+++ b/action.sh
@@ -215,6 +215,7 @@ function start_vm {
 
 	cat <<-EOF > /usr/bin/gce_runner_shutdown.sh
 	#!/bin/sh
+  /actions-runner/svc.sh uninstall
   RUNNER_ALLOW_RUNASROOT=1 /actions-runner/config.sh remove --token ${RUNNER_TOKEN}
 	echo \"✅ Self deleting $VM_ID in ${machine_zone} in ${shutdown_timeout} seconds ...\"
 	# We tear down the machine by starting the systemd service that was registered by the startup script

--- a/action.sh
+++ b/action.sh
@@ -197,6 +197,9 @@ function start_vm {
 	cat <<-EOF > /etc/systemd/system/shutdown.sh
 	#!/bin/sh
 	sleep ${shutdown_timeout}
+  cd /actions-runner
+  sudo ./svc.sh uninstall
+  RUNNER_ALLOW_RUNASROOT=1 ./config.sh remove --token ${RUNNER_TOKEN}
 	gcloud compute instances delete $VM_ID --zone=$machine_zone --quiet
 	EOF
 
@@ -215,9 +218,6 @@ function start_vm {
 
 	cat <<-EOF > /usr/bin/gce_runner_shutdown.sh
 	#!/bin/sh
-  cd /actions-runner
-  sudo ./svc.sh uninstall
-  RUNNER_ALLOW_RUNASROOT=1 ./config.sh remove --token ${RUNNER_TOKEN}
 	echo \"✅ Self deleting $VM_ID in ${machine_zone} in ${shutdown_timeout} seconds ...\"
 	# We tear down the machine by starting the systemd service that was registered by the startup script
 	systemctl start shutdown.service

--- a/action.sh
+++ b/action.sh
@@ -215,8 +215,9 @@ function start_vm {
 
 	cat <<-EOF > /usr/bin/gce_runner_shutdown.sh
 	#!/bin/sh
-  /actions-runner/svc.sh uninstall
-  RUNNER_ALLOW_RUNASROOT=1 /actions-runner/config.sh remove --token ${RUNNER_TOKEN}
+  cd /actions-runner
+  sudo ./svc.sh uninstall
+  RUNNER_ALLOW_RUNASROOT=1 ./config.sh remove --token ${RUNNER_TOKEN}
 	echo \"✅ Self deleting $VM_ID in ${machine_zone} in ${shutdown_timeout} seconds ...\"
 	# We tear down the machine by starting the systemd service that was registered by the startup script
 	systemctl start shutdown.service

--- a/action.sh
+++ b/action.sh
@@ -215,6 +215,7 @@ function start_vm {
 
 	cat <<-EOF > /usr/bin/gce_runner_shutdown.sh
 	#!/bin/sh
+  /actions-runner/config.sh remove --token ${RUNNER_TOKEN}
 	echo \"✅ Self deleting $VM_ID in ${machine_zone} in ${shutdown_timeout} seconds ...\"
 	# We tear down the machine by starting the systemd service that was registered by the startup script
 	systemctl start shutdown.service

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
       The service account key which will be used for authentication credentials.
       This key should be created and stored as a secret. Should be JSON key.
     required: false
+  vm_id:
+    required: false
   runner_ver:
     description: Version of the GitHub Runner. "latest" will resolve the latest version.
     default: "latest"
@@ -135,4 +137,5 @@ runs:
         --actions_preinstalled=${{ inputs.actions_preinstalled }}
         --maintenance_policy_terminate=${{ inputs.maintenance_policy_terminate }}
         --arm=${{ inputs.arm }}
+        --vm_id=${{ inputs.vm_id }}
       shell: bash


### PR DESCRIPTION
By default this library creates a runner with the name gh-action-runner-${workflow_run_id}-${run_number} ... and after the runner runs a single job, it is shut down. Therefore only one runner can be created in a workflow, and only one job can be ran by that runner.

This adds a vm-suffix so you can create multiple runners in a single workflow and they can each run their one job.
